### PR TITLE
Small changes to fix build

### DIFF
--- a/VacuumMeshing/include/SurfaceMeshing/SurfaceGenerator.hpp
+++ b/VacuumMeshing/include/SurfaceMeshing/SurfaceGenerator.hpp
@@ -69,6 +69,8 @@ public:
       std::vector<int> &connectivity,
       std::map<int, std::vector<libMesh::boundary_id_type>> &boundary_data);
 
+  std::multimap<unsigned int, unsigned int> surface_face_map;
+
 protected:
   /** Method for checking whether an element has sides which should be in the
    * skin. Looks at the sides (faces or edges, depends if 2D or 3D element) of
@@ -108,7 +110,7 @@ protected:
   /**
    *
    */
-  std::multimap<unsigned int, unsigned int> surface_face_map;
+  // std::multimap<unsigned int, unsigned int> surface_face_map;
   // Mesh references
   libMesh::Mesh &mesh, &surfaceMesh;
 

--- a/VacuumMeshing/include/SurfaceMeshing/SurfaceGenerator.hpp
+++ b/VacuumMeshing/include/SurfaceMeshing/SurfaceGenerator.hpp
@@ -110,7 +110,6 @@ protected:
   /**
    *
    */
-  // std::multimap<unsigned int, unsigned int> surface_face_map;
   // Mesh references
   libMesh::Mesh &mesh, &surfaceMesh;
 

--- a/VacuumMeshing/include/VacuumGeneration/VacuumGenerator.hpp
+++ b/VacuumMeshing/include/VacuumGeneration/VacuumGenerator.hpp
@@ -64,7 +64,7 @@ protected:
   double merge_tolerance_ = 1e-07;
   double seeding_tolerance_ = 1e-07;
 
-  std::multimap<unsigned int, unsigned int>* surface_face_map_;
+  const std::multimap<unsigned int, unsigned int>* surface_face_map_;
 
 private:
 };

--- a/VacuumMeshing/src/BoundaryGeneration/BoundaryGenerator.cpp
+++ b/VacuumMeshing/src/BoundaryGeneration/BoundaryGenerator.cpp
@@ -27,7 +27,7 @@ void BoundaryGenerator::addBoundary(double length, int subdivisions,
   }
 
   // Turn IGL mesh into libmesh Mesh
-  IGLToLibMesh(boundary_mesh_, boundary_verts, boundary_elems);
+  IGLToLibMesh(boundary_mesh_, boundary_vertices, boundary_elements);
 
   // If unspecified, get merge tolerance
   if (mesh_merge_tolerance_ == 0) {


### PR DESCRIPTION
Seems in `BoundaryGenerator.cpp`, variables were renamed from `boundary_verts` to `boundary_vertices`, but missed in one place. I fixed this.

Also fixed issue in converting from const to non-const in VacuumGenerator.hpp.

In SurfaceGenerator, I needed to change `surface_face_map` to public.

This fixes some of the build issues I mentioned in #16.