### PR TITLE
Fixed Cubic boundary generation.

### DIFF
--- a/VacuumMeshing/include/BoundaryGeneration/BoundaryGenerator.hpp
+++ b/VacuumMeshing/include/BoundaryGeneration/BoundaryGenerator.hpp
@@ -62,6 +62,15 @@ public:
   void genSquare(Eigen::MatrixXd &edge_verts, Eigen::MatrixXi &edge_elems, double length,
                  int subdivisions);
 
+    /** Method generates a square boundary comprised of just edge elements.
+   \c verts  will be populated with the vertex data, \c elems will be populated
+   with the element connectivity data. \c length and \c subdivisions allow the
+   user to change the length of the edges of the square, as well as how many
+   elements there should be per edge*/
+  void genTriangulatedSquare(Eigen::MatrixXd &edge_verts, Eigen::MatrixXi &edge_elems, double length,
+                 int subdivisions, std::string tri_flags);
+
+
   /** Method for combining two libigl meshes that you are SURE do NOT intersect
    and DO NOT have duplicate nodes. There is a combine meshes method in
    removeDupeNodes.cpp that can combine meshes with duplicate nodes using an

--- a/VacuumMeshing/src/BoundaryGeneration/BoundaryGenerator.cpp
+++ b/VacuumMeshing/src/BoundaryGeneration/BoundaryGenerator.cpp
@@ -151,11 +151,21 @@ void BoundaryGenerator::genBoundingBoxBoundary(Eigen::MatrixXd &boundary_vertice
   Eigen::MatrixXi xy_elems, xz_elems, yz_elems;
   Eigen::MatrixXd seeds;
 
-  // Get number of elements along each axis
+  // Get the number of elements along each axis, and store this info
   int x_subdiv, y_subdiv, z_subdiv;
   x_subdiv = subdivisions;
   y_subdiv = (bb_y_dim/bb_x_dim) * x_subdiv;
   z_subdiv = (bb_z_dim/bb_x_dim) * x_subdiv;
+
+  /**
+   * For a structure which is very thin in one dimension, the number of subdivisions
+   * in this dimension may be evaluated as 0. This is not a valid number of subdivions, so
+   * a lower limit of 2 is set. 
+   */
+  // 
+  x_subdiv == 0 ? x_subdiv += 2 : ;
+  y_subdiv == 0 ? x_subdiv += 2 : ;
+  z_subdiv == 0 ? x_subdiv += 2 : ;
 
   // Create a square from 1st order edge elements
   genTriangulatedRect(xy_verts, xy_elems, bb_x_dim, bb_y_dim, x_subdiv, y_subdiv, tri_flags);

--- a/VacuumMeshing/src/BoundaryGeneration/BoundaryGenerator.cpp
+++ b/VacuumMeshing/src/BoundaryGeneration/BoundaryGenerator.cpp
@@ -152,7 +152,7 @@ void BoundaryGenerator::genBoundingBoxBoundary(Eigen::MatrixXd &boundary_vertice
   Eigen::MatrixXd seeds;
 
   // Get number of elements along each axis
-  double x_subdiv, y_subdiv, z_subdiv;
+  int x_subdiv, y_subdiv, z_subdiv;
   x_subdiv = subdivisions;
   y_subdiv = (bb_y_dim/bb_x_dim) * x_subdiv;
   z_subdiv = (bb_z_dim/bb_x_dim) * x_subdiv;


### PR DESCRIPTION
**Cubic Boundaries**
When using `--boundary_type Cube`, previously the `BoundaryGenerator::genBoundary()` method was calling `BoundaryGenerator::genSquare()`, which returns only the edges (boundary elements) of a square. Importantly, the square was NOT being tessellated yet, so the resulting boundary was completely invalid. Now BoundaryGenerator::genTriangulatedSquare has been added, #18 should be fixed.

**Bounding Box Boundaries**
Previous to this PR `BoundaryGenerator::genBoundingBoxBoundary()` could wrongly set the boundary mesh subdivisions to 0 on one of the 3 axes if the structure being vacuum meshes is much thinner in one dimension. Now a minimum of 2 subdivisions is enforced in all axes to ensure a valid mesh is generated.